### PR TITLE
Fix for the hour value depicted as a float value in CPU and Job Runtime

### DIFF
--- a/lib/galaxy/job_metrics/formatting.py
+++ b/lib/galaxy/job_metrics/formatting.py
@@ -15,4 +15,4 @@ def seconds_to_str(value):
     elif value < 3600:
         return "%s minutes" % round(value / 60, 2)
     else:
-        return "{} hours and {} minutes".format(round(value / 3600, 2), round((value % 3600) / 60, 2))
+        return "{} hours and {} minutes".format(int(value / 3600), round((value % 3600) / 60, 2))


### PR DESCRIPTION
Hours in CPU and Job Runtime are displayed as a float value of the **full** CPU and Job Runtime, respectively.
![grafik](https://user-images.githubusercontent.com/34959927/91420612-3c509680-e855-11ea-8d9d-e32977d3383f.png)

This fix floors the hour value.
